### PR TITLE
fix: improve point and spot light handling in voxel lighting system

### DIFF
--- a/package/Runtime/Debug/RadianceFieldVisualizer.cs
+++ b/package/Runtime/Debug/RadianceFieldVisualizer.cs
@@ -12,7 +12,7 @@ namespace Lotec.Lighting {
         SdfShaderGlobals _sdfShaderGlobals;
         int _lastStatusFrame;
         protected override string ConversionShaderName => "Hidden/Unpack3D";
-        LightingVolume Volume => LightingManager.Instance.Volume;
+        LightingVolume Volume => LightingManager.Instance != null ? LightingManager.Instance.Volume : null;
 
         protected override Texture GetTexture() {
             if (source == null) {
@@ -24,9 +24,6 @@ namespace Lotec.Lighting {
             if (rt == null) { LogStatus("GetTexture: current radiance RT is null"); return null; }
             if (!rt.IsCreated()) rt.Create();
             if (rt.width == 0 || rt.height == 0 || rt.volumeDepth == 0) { LogStatus($"GetTexture: RT has invalid dims {rt.width}x{rt.height}x{rt.volumeDepth}"); return null; }
-
-            if (Time.frameCount - _lastStatusFrame < 10) return null;
-            _lastStatusFrame = Time.frameCount;
 
             return rt;
         }

--- a/package/Runtime/Debug/RadianceFieldVisualizer.cs
+++ b/package/Runtime/Debug/RadianceFieldVisualizer.cs
@@ -7,7 +7,6 @@ namespace Lotec.Lighting {
         public bool toneMap = true;
         [Min(0f)] public float exposure = 1.0f;
         [Min(0f)] public float minVisibleLuminance = 0.02f;
-        public bool showZeroAsGray = true;
 
         SdfShaderGlobals _sdfShaderGlobals;
         int _lastStatusFrame;
@@ -41,19 +40,12 @@ namespace Lotec.Lighting {
         protected override Color ProcessColor(Color c) {
             c.a = 1f;
 
-            // Assume c is linear HDR. Evaluate luminance in linear space first.
+            // Assume c is linear HDR. Use minVisibleLuminance as a hard visibility threshold.
             float lumLinear = 0.2126f * c.r + 0.7152f * c.g + 0.0722f * c.b;
 
-            if (lumLinear <= 0.0f && showZeroAsGray) {
-                c = new Color(minVisibleLuminance, minVisibleLuminance, minVisibleLuminance, 1.0f);
-            } else if (lumLinear > 0.0f && lumLinear < minVisibleLuminance) {
-                float scale = minVisibleLuminance / lumLinear;
-                c = new Color(
-                    Mathf.Min(c.r * scale, 1f),
-                    Mathf.Min(c.g * scale, 1f),
-                    Mathf.Min(c.b * scale, 1f),
-                    1f
-                );
+            if (lumLinear < minVisibleLuminance) {
+                c.a = 0f;
+                return c;
             }
 
             if (toneMap) c = ApplyToneMap(c, exposure);
@@ -67,7 +59,7 @@ namespace Lotec.Lighting {
                 v.r / (1.0f + v.r),
                 v.g / (1.0f + v.g),
                 v.b / (1.0f + v.b),
-                1.0f
+                c.a
             );
         }
 

--- a/package/Runtime/Debug/VoxelFieldVisualizerBase.cs
+++ b/package/Runtime/Debug/VoxelFieldVisualizerBase.cs
@@ -89,6 +89,8 @@ namespace Lotec.Lighting {
                         if (idx < 0 || idx >= _cachedPixels.Length) continue;
 
                         Color c = ProcessColor(_cachedPixels[idx]);
+                        if (c.a <= 0f) continue;
+
                         Vector3 localNorm = new Vector3((x + 0.5f) / _rx, (y + 0.5f) / _ry, (z + 0.5f) / _rz);
                         Vector3 pos = bounds.min + Vector3.Scale(localNorm, bounds.size);
 
@@ -126,6 +128,7 @@ namespace Lotec.Lighting {
                         if (idx < 0 || idx >= _cachedPixels.Length) continue;
 
                         Color c = ProcessColor(_cachedPixels[idx]);
+                        if (c.a <= 0f) continue;
                         Vector3 localNorm = new Vector3((x + 0.5f) / _rx, (y + 0.5f) / _ry, (z + 0.5f) / _rz);
                         Vector3 pos = bounds.min + Vector3.Scale(localNorm, bounds.size);
 

--- a/package/Runtime/Debug/VoxelFieldVisualizerBase.cs
+++ b/package/Runtime/Debug/VoxelFieldVisualizerBase.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.Rendering;
 
 namespace Lotec.Lighting {
     /// <summary>
@@ -9,11 +10,16 @@ namespace Lotec.Lighting {
     public abstract class VoxelFieldVisualizerBase : MonoBehaviour {
         [Min(1)] public int skip = 2;
         [Min(0f)] public float sphereRadius = 0.02f;
+        [Min(1)] public int refreshInterval = 10;
+        [SerializeField] bool _showInGameView;
 
         Texture _currentTex;
         Color[] _cachedPixels;
         int _rx, _ry, _rz;
         bool _readbackInProgress;
+        int _lastReadbackFrame = -9999;
+
+        static Material _glMaterial;
 
         protected virtual string ConversionShaderName => null;
 
@@ -23,39 +29,42 @@ namespace Lotec.Lighting {
         protected virtual Color ProcessColor(Color c) => c;
 
         void OnEnable() {
-            CacheIfNeeded();
+            _lastReadbackFrame = -9999;
+            TryStartReadback();
+            RenderPipelineManager.endCameraRendering += OnEndCameraRendering;
         }
 
         void OnDisable() {
             _cachedPixels = null;
             _readbackInProgress = false;
+            RenderPipelineManager.endCameraRendering -= OnEndCameraRendering;
         }
 
         void OnValidate() {
-            CacheIfNeeded();
+            _lastReadbackFrame = -9999;
+            TryStartReadback();
         }
 
         void Update() {
-            if (!Application.isPlaying) CacheIfNeeded();
+            if (Time.frameCount - _lastReadbackFrame >= refreshInterval) {
+                TryStartReadback();
+            }
         }
 
-        void CacheIfNeeded() {
+        // Readback is throttled to once every refreshInterval frames.
+        // _cachedPixels is never nulled between readbacks — the last good frame stays visible.
+        void TryStartReadback() {
             Texture tex = GetTexture();
-            if (tex == _currentTex && _cachedPixels != null)
-                return;
-
-            _currentTex = tex;
-            _cachedPixels = null;
-
-            if (_currentTex == null) return;
+            if (tex == null) return;
             if (_readbackInProgress) return;
 
+            _currentTex = tex;
+            _lastReadbackFrame = Time.frameCount;
             _readbackInProgress = true;
             Texture3DReadback.ReadbackRGBAAsync(_currentTex, ConversionShaderName, (success, pixels, w, h, d) => {
                 _readbackInProgress = false;
                 if (!success) {
                     Debug.LogWarning($"{GetType().Name}: cannot read pixels from texture '{_currentTex?.name}'.");
-                    _cachedPixels = null;
                     return;
                 }
 
@@ -67,6 +76,7 @@ namespace Lotec.Lighting {
         }
 
         void OnDrawGizmos() {
+            if (_showInGameView) return;
             if (!enabled) return;
             if (_cachedPixels == null) return;
             if (_rx <= 0 || _ry <= 0 || _rz <= 0) return;
@@ -76,11 +86,9 @@ namespace Lotec.Lighting {
                 for (int y = 0; y < _ry; y += skip) {
                     for (int x = 0; x < _rx; x += skip) {
                         int idx = x + y * _rx + z * _rx * _ry;
-                        if (idx < 0 || idx >= _cachedPixels.Length)
-                            continue;
+                        if (idx < 0 || idx >= _cachedPixels.Length) continue;
 
                         Color c = ProcessColor(_cachedPixels[idx]);
-
                         Vector3 localNorm = new Vector3((x + 0.5f) / _rx, (y + 0.5f) / _ry, (z + 0.5f) / _rz);
                         Vector3 pos = bounds.min + Vector3.Scale(localNorm, bounds.size);
 
@@ -89,6 +97,62 @@ namespace Lotec.Lighting {
                     }
                 }
             }
+        }
+
+        // Game-view rendering using the URP end-camera callback so draws land on top
+        // of the final blitted image. GL.Lines are batched into a single draw call.
+        void OnEndCameraRendering(ScriptableRenderContext ctx, Camera cam) {
+            if (!_showInGameView) return;
+            if (!enabled) return;
+            if (cam.cameraType != CameraType.Game) return;
+            if (_cachedPixels == null) return;
+            if (_rx <= 0 || _ry <= 0 || _rz <= 0) return;
+            if (!TryGetBounds(out Bounds bounds)) return;
+
+            Material mat = GetOrCreateGLMaterial();
+            if (mat == null) return;
+
+            mat.SetPass(0);
+            GL.PushMatrix();
+            GL.LoadProjectionMatrix(cam.projectionMatrix);
+            GL.modelview = cam.worldToCameraMatrix;
+            GL.Begin(GL.LINES);
+
+            float r = sphereRadius;
+            for (int z = 0; z < _rz; z += skip) {
+                for (int y = 0; y < _ry; y += skip) {
+                    for (int x = 0; x < _rx; x += skip) {
+                        int idx = x + y * _rx + z * _rx * _ry;
+                        if (idx < 0 || idx >= _cachedPixels.Length) continue;
+
+                        Color c = ProcessColor(_cachedPixels[idx]);
+                        Vector3 localNorm = new Vector3((x + 0.5f) / _rx, (y + 0.5f) / _ry, (z + 0.5f) / _rz);
+                        Vector3 pos = bounds.min + Vector3.Scale(localNorm, bounds.size);
+
+                        GL.Color(c);
+                        GL.Vertex3(pos.x - r, pos.y, pos.z); GL.Vertex3(pos.x + r, pos.y, pos.z);
+                        GL.Vertex3(pos.x, pos.y - r, pos.z); GL.Vertex3(pos.x, pos.y + r, pos.z);
+                        GL.Vertex3(pos.x, pos.y, pos.z - r); GL.Vertex3(pos.x, pos.y, pos.z + r);
+                    }
+                }
+            }
+
+            GL.End();
+            GL.PopMatrix();
+        }
+
+        static Material GetOrCreateGLMaterial() {
+            if (_glMaterial != null) return _glMaterial;
+
+            Shader shader = Shader.Find("Hidden/Internal-Colored");
+            if (shader == null) return null;
+
+            _glMaterial = new Material(shader) { hideFlags = HideFlags.HideAndDontSave };
+            _glMaterial.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.SrcAlpha);
+            _glMaterial.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
+            _glMaterial.SetInt("_Cull", (int)UnityEngine.Rendering.CullMode.Off);
+            _glMaterial.SetInt("_ZWrite", 0);
+            return _glMaterial;
         }
     }
 }

--- a/package/Runtime/GiFieldUpdater.cs
+++ b/package/Runtime/GiFieldUpdater.cs
@@ -68,6 +68,8 @@ namespace Lotec.Lighting {
         int _irradianceFieldSampleCount;
         GraphicsFormat _giTextureFormat;
         LightSettings _prevLightSettings;
+        int _currentPointLightCount;
+        int _currentSpotLightCount;
         readonly Vector4[] _pointLightPositionRanges = new Vector4[LightingManager.MaxPointLights];
         readonly Vector4[] _pointLightColors = new Vector4[LightingManager.MaxPointLights];
         readonly Vector4[] _spotLightPositionRanges = new Vector4[LightingManager.MaxSpotLights];
@@ -114,6 +116,43 @@ namespace Lotec.Lighting {
         public LightingVolume Volume { get; set; }
 
         LightingManager Manager => LightingManager.Instance;
+
+        Vector3 GetTextureVoxelSize(Texture3D texture) {
+            if (texture == null) {
+                return Vector3.one;
+            }
+
+            return new Vector3(
+                Volume.Bounds.size.x / Mathf.Max(1, texture.width),
+                Volume.Bounds.size.y / Mathf.Max(1, texture.height),
+                Volume.Bounds.size.z / Mathf.Max(1, texture.depth));
+        }
+
+        bool TryGetCubicVoxelSize(Texture3D texture, out float voxelSize, out string reason) {
+            Vector3 voxelSize3 = GetTextureVoxelSize(texture);
+            float minVoxelSize = Mathf.Min(voxelSize3.x, Mathf.Min(voxelSize3.y, voxelSize3.z));
+            float maxVoxelSize = Mathf.Max(voxelSize3.x, Mathf.Max(voxelSize3.y, voxelSize3.z));
+            float tolerance = Mathf.Max(1e-5f, maxVoxelSize * 0.1f);
+
+            if (maxVoxelSize - minVoxelSize > tolerance) {
+                voxelSize = maxVoxelSize;
+                reason = $"{texture.name} resolves to non-cubic voxels ({voxelSize3}). Runtime GI assumes cubic voxels; recompute bounds and rebake the SDF/GI textures.";
+                return false;
+            }
+
+            voxelSize = maxVoxelSize;
+            reason = null;
+            return true;
+        }
+
+        float GetGiGridVoxelSize() {
+            // GI centers, SDF distances, and runtime irradiance reads all live on the
+            // low-res SDF / GI grid. The material field can be a different resolution,
+            // but it is only sampled by normalized UVW, so its texel size must not drive
+            // shell widths, start offsets, or runtime read offsets.
+            TryGetCubicVoxelSize(SurfaceDistanceFieldLowRes, out float voxelSize, out _);
+            return voxelSize;
+        }
 
         public bool SetLightingMethod(LightingMethod lightingMethod) {
             if (_lightingMethod == lightingMethod) {
@@ -225,6 +264,10 @@ namespace Lotec.Lighting {
 
             if (SurfaceDistanceFieldLowRes == null) {
                 reason = "LightingVolume.sdfLowresTexture";
+                return false;
+            }
+
+            if (!TryGetCubicVoxelSize(SurfaceDistanceFieldLowRes, out _, out reason)) {
                 return false;
             }
 
@@ -446,9 +489,8 @@ namespace Lotec.Lighting {
 
         void DispatchGIUpdate() {
             // Shared parameters
-            Vector3 resolution = MaterialFieldAlbedoIntensity.GetResolution();
-            float voxelSize = (float)Volume.Bounds.size.x / resolution.x;
-            _giComputeShader.SetVector(s_voxelSize, voxelSize * Vector4.one);
+            float voxelSize = GetGiGridVoxelSize();
+            _giComputeShader.SetVector(s_voxelSize, voxelSize * Vector3.one);
             _giComputeShader.SetInt(s_frameCount, Time.frameCount);
             _giComputeShader.SetVector(s_radianceTextureSize, _radianceTextureResolution);
             _giComputeShader.SetInt(s_raysPerFrame, _raysPerFrame);
@@ -596,6 +638,7 @@ namespace Lotec.Lighting {
                 }
             }
 
+            _currentPointLightCount = pointLightCount;
             _giComputeShader.SetInt(s_pointLightCount, pointLightCount);
             _giComputeShader.SetVectorArray(s_pointLightPositionRange, _pointLightPositionRanges);
             _giComputeShader.SetVectorArray(s_pointLightColor, _pointLightColors);
@@ -634,6 +677,7 @@ namespace Lotec.Lighting {
                 }
             }
 
+            _currentSpotLightCount = spotLightCount;
             _giComputeShader.SetInt(s_spotLightCount, spotLightCount);
             _giComputeShader.SetVectorArray(s_spotLightPositionRange, _spotLightPositionRanges);
             _giComputeShader.SetVectorArray(s_spotLightDirectionAngleScale, _spotLightDirectionAngleScales);
@@ -661,11 +705,24 @@ namespace Lotec.Lighting {
             // LPV uses the direct ping-pong output (no blur).
             // PathTracing uses the separate blurred irradiance texture.
             Shader.SetGlobalTexture(s_irradianceFieldFinal, _lightingMethod == LightingMethod.LPV ? IrradianceFinal : _irradianceFieldFinal);
+            Shader.SetGlobalTexture(s_distanceField, SurfaceDistanceFieldLowRes);
 
             // Update these every frame in case the volume moves
-            Vector3 resolution = MaterialFieldAlbedoIntensity.GetResolution();
-            float voxelSize = MaterialFieldAlbedoIntensity.width / resolution.x;
-            Shader.SetGlobalVector(s_radianceFieldVoxelSize, voxelSize * Vector4.one);
+            // The runtime GI include samples the irradiance volume, so use the GI grid
+            // spacing here as well. A different material-field resolution should not
+            // change the surface read offset in SampleVoxelGI.
+            float voxelSize = GetGiGridVoxelSize();
+            Shader.SetGlobalVector(s_radianceFieldVoxelSize, voxelSize * Vector3.one);
+
+            // Visible local-light direct shading now runs in the fragment shader,
+            // so publish the curated point/spot light arrays there as globals too.
+            Shader.SetGlobalInt(s_pointLightCount, _currentPointLightCount);
+            Shader.SetGlobalVectorArray(s_pointLightPositionRange, _pointLightPositionRanges);
+            Shader.SetGlobalVectorArray(s_pointLightColor, _pointLightColors);
+            Shader.SetGlobalInt(s_spotLightCount, _currentSpotLightCount);
+            Shader.SetGlobalVectorArray(s_spotLightPositionRange, _spotLightPositionRanges);
+            Shader.SetGlobalVectorArray(s_spotLightDirectionAngleScale, _spotLightDirectionAngleScales);
+            Shader.SetGlobalVectorArray(s_spotLightColorAngleOffset, _spotLightColorAngleOffsets);
         }
     }
 

--- a/package/Runtime/LightingVolume.cs
+++ b/package/Runtime/LightingVolume.cs
@@ -97,15 +97,23 @@ namespace Lotec.Lighting {
             float maxAxis = Mathf.Max(size.x, Mathf.Max(size.y, size.z));
             maxAxis = Mathf.Max(0.0001f, maxAxis);
 
-            float voxelSizeX = maxAxis / _maxResolution;
-            voxelSizeX = Mathf.Max(0.0001f, voxelSizeX);
+            float voxelSize = maxAxis / _maxResolution;
+            voxelSize = Mathf.Max(0.0001f, voxelSize);
 
-            int rx = Mathf.Clamp(Mathf.CeilToInt(size.x / voxelSizeX), 4, _maxResolution);
-            int ry = Mathf.Clamp(Mathf.CeilToInt(size.y / voxelSizeX), 4, _maxResolution);
-            int rz = Mathf.Clamp(Mathf.CeilToInt(size.z / voxelSizeX), 4, _maxResolution);
+            int rx = Mathf.Clamp(Mathf.CeilToInt(size.x / voxelSize), 4, _maxResolution);
+            int ry = Mathf.Clamp(Mathf.CeilToInt(size.y / voxelSize), 4, _maxResolution);
+            int rz = Mathf.Clamp(Mathf.CeilToInt(size.z / voxelSize), 4, _maxResolution);
 
             TrimmedMaxResolution = new Vector3Int(rx, ry, rz);
-            _voxelSize = Vector3.Scale(Bounds.size, new Vector3(1.0f / TrimmedMaxResolution.x, 1.0f / TrimmedMaxResolution.y, 1.0f / TrimmedMaxResolution.z));
+
+            // Enforce cubic voxels by expanding the bounds to an integer number of
+            // cells of the chosen voxel size on every axis. Without this adjustment,
+            // the ceil() above would make the effective voxel size drift per axis and
+            // the runtime GI shaders would silently stop agreeing on shell widths,
+            // offsets, and distance thresholds.
+            Vector3 alignedSize = new Vector3(rx * voxelSize, ry * voxelSize, rz * voxelSize);
+            Bounds = new Bounds(Bounds.center, alignedSize);
+            _voxelSize = Vector3.one * voxelSize;
         }
     }
 }

--- a/package/Runtime/SdfShaderGlobals.cs
+++ b/package/Runtime/SdfShaderGlobals.cs
@@ -10,7 +10,6 @@ namespace Lotec.Lighting {
         static readonly int sSdfBoundsSize = Shader.PropertyToID("_SdfBoundsSize");
         static readonly int sInverseVoxelSize = Shader.PropertyToID("_InverseVoxelSize");
         static readonly int sVoxelResolution = Shader.PropertyToID("_VoxelResolution");
-        static readonly int sShadowMaxDistance = Shader.PropertyToID("_SdfShadowMaxDistance");
         static readonly int sShadowMaxSteps = Shader.PropertyToID("_SdfShadowMaxSteps");
         static readonly int sShadowSoftness = Shader.PropertyToID("_SdfShadowSoftness");
         static readonly int sShadowEpsilon = Shader.PropertyToID("_SdfShadowEpsilon");
@@ -25,7 +24,6 @@ namespace Lotec.Lighting {
         public LightingVolume Volume { get; set; }
 
         [Header("Shadow Raymarch")]
-        [Min(0f)] public float shadowMaxDistance = 10f;
         [Min(1)] public int shadowMaxSteps = 64;
         [Min(0.000001f)] public float shadowEpsilon = 0.02f;
         [Min(1f)] public float shadowSoftness = 16.0f;
@@ -103,7 +101,6 @@ namespace Lotec.Lighting {
                 1.0f / Mathf.Max(1e-9f, voxelSize.y),
                 1.0f / Mathf.Max(1e-9f, voxelSize.z));
             Shader.SetGlobalVector(sInverseVoxelSize, invVoxelSize);
-            Shader.SetGlobalFloat(sShadowMaxDistance, shadowMaxDistance);
             Shader.SetGlobalInt(sShadowMaxSteps, shadowMaxSteps);
             Shader.SetGlobalFloat(sShadowSoftness, shadowSoftness);
             Shader.SetGlobalFloat(sShadowEpsilon, shadowEpsilon);

--- a/package/Runtime/Shaders/Compute/VoxelGiUpdate.compute
+++ b/package/Runtime/Shaders/Compute/VoxelGiUpdate.compute
@@ -207,7 +207,7 @@ void CSComputeIrradiancePathTracing(uint3 id : SV_DispatchThreadID)
     for (uint rayIndex = 0u; rayIndex < rayCount; rayIndex++) {
         float2 noise2 = GetBlueNoise2(_BlueNoiseTex, id, _FrameCount, rayIndex);
         half3 rayDir;
-        if (isAir) {
+        if (!isAir) {
             rayDir = CosineSampleHemisphere(surfaceNormal, noise2);
         } else {
             rayDir = GetRandomDirectionFromNoise2(noise2);

--- a/package/Runtime/Shaders/Compute/VoxelGiUpdate.compute
+++ b/package/Runtime/Shaders/Compute/VoxelGiUpdate.compute
@@ -10,6 +10,7 @@
 // Keep in sync with LightingManager.MaxPointLights and MaxSpotLights.
 #define MAX_POINT_LIGHTS 4
 #define MAX_SPOT_LIGHTS 4
+#define MAX_SDF_DIST 1.0e+10
 
 #include "../Includes/Volume.hlsl"
 #include "../Includes/Fibonacci.hlsl"
@@ -67,7 +68,7 @@ float GetLocalLightRangeAttenuation(float distSq, float rangeSq)
     return rangeFade * rangeFade;
 }
 
-float3 GetPointLight(float3 voxelCenter)
+float3 GetPointLight(float3 voxelCenter, float startOffset)
 {
     float3 totalLight = 0.0;
     uint pointLightCount = min(_PointLightCount, (uint)MAX_POINT_LIGHTS);
@@ -86,7 +87,7 @@ float3 GetPointLight(float3 voxelCenter)
         float distanceToLight = distSq * invDistance;
         float3 lightDir = toLight * invDistance;
         float3 hitPos;
-        float visibility = RaymarchSDF(voxelCenter, lightDir, distanceToLight, hitPos);
+        float visibility = RaymarchSDF(voxelCenter, lightDir, startOffset, distanceToLight, hitPos);
         float attenuation = visibility * GetLocalLightRangeAttenuation(distSq, rangeSq);
         totalLight += _PointLightColor[lightIndex].rgb * attenuation;
     }
@@ -94,7 +95,7 @@ float3 GetPointLight(float3 voxelCenter)
     return totalLight;
 }
 
-float3 GetSpotLight(float3 voxelCenter)
+float3 GetSpotLight(float3 voxelCenter, float startOffset)
 {
     float3 totalLight = 0.0;
     uint spotLightCount = min(_SpotLightCount, (uint)MAX_SPOT_LIGHTS);
@@ -121,7 +122,7 @@ float3 GetSpotLight(float3 voxelCenter)
         }
 
         float3 hitPos;
-        float visibility = RaymarchSDF(voxelCenter, lightDir, distanceToLight, hitPos);
+        float visibility = RaymarchSDF(voxelCenter, lightDir, startOffset, distanceToLight, hitPos);
         float attenuation = visibility * GetLocalLightRangeAttenuation(distSq, rangeSq) * (coneAttenuation * coneAttenuation);
         totalLight += colorAngleOffset.rgb * attenuation;
     }
@@ -139,6 +140,7 @@ void CSClearVolume(uint3 id : SV_DispatchThreadID)
 // ----------------------------------------------------------
 // RADIANCE PASS
 // Calculate how much light this voxel emits.
+// Only near-surface voxels emit light, to limit light bleeding and keep the GI field more stable.
 // ----------------------------------------------------------
 [numthreads(8, 8, 8)]
 void CSComputeRadiance(uint3 id : SV_DispatchThreadID)
@@ -152,8 +154,11 @@ void CSComputeRadiance(uint3 id : SV_DispatchThreadID)
     bool shouldInjectSky = _InjectLpvSky != 0 && isAir && HasOpenSky(id);
     float3 outgoingLight = shouldInjectSky ? _SkyColor : 0.0;
 
-    // Only near-surface voxels radiate.
-    bool shouldRadiate = dist > 0 && dist <= _VoxelSize.x;
+    // Only near-surface voxels radiate. dist >= 0 includes voxels exactly on the
+    // surface (e.g. wall mesh perfectly aligned to the voxel grid). LightingVolume
+    // expands bounds so the GI/SDF grid stays cubic, so _VoxelSize.x is the single
+    // world-space edge length for this grid.
+    bool shouldRadiate = dist >= 0 && dist <= _VoxelSize.x;
     if (!shouldRadiate) {
         _RadianceFieldWrite[id] = float4(outgoingLight, 1.0);
         return;
@@ -161,13 +166,28 @@ void CSComputeRadiance(uint3 id : SV_DispatchThreadID)
 
     // Get indirect light from GI field.
     float3 surfaceIrradiance = _IrradianceFieldHistory.SampleLevel(pointClampSampler, uvw, 0).rgb;
+    // -- Self-occlusion bias (start offset for shadow rays) --
+    //
+    // RayMarchTex3D treats any sample with d <= EPSILON as a hit. A near-surface
+    // voxel whose own center sits inside that EPSILON shell would therefore
+    // self-occlude every shadow ray on the very first step, regardless of which
+    // direction the ray points, leaving the voxel permanently black.
+    //
+    // We skip past the shell by giving the raymarcher a startOffset large
+    // enough to clear EPSILON plus one minimum raymarch step. Using only
+    // EPSILON is not enough because the hit test is d <= EPSILON, so a sample
+    // that lands exactly on the threshold still self-hits.
+    //
+    // If EPSILON or RAYMARCH_MIN_STEP changes in Volume.hlsl, this helper
+    // stays in sync automatically.
+    float startOffset = ComputeRaymarchStartOffset(dist);
     // Get direct sun light
     // TODO: Optimize by sampling a shadowmap as a crude first step, then only raymarch if needed?
     float3 hitPos;
-    float sunVisibility = RaymarchSDF(voxelCenter, _DirectLightDir, hitPos);
+    float sunVisibility = RaymarchSDF(voxelCenter, _DirectLightDir, startOffset, MAX_SDF_DIST, hitPos);
     float3 sunLight = _DirectLightColor.rgb * sunVisibility;
-    float3 pointLight = GetPointLight(voxelCenter);
-    float3 spotLight = GetSpotLight(voxelCenter);
+    float3 pointLight = GetPointLight(voxelCenter, startOffset);
+    float3 spotLight = GetSpotLight(voxelCenter, startOffset);
     // Get surface albedo and emissive intensity (alpha is 8-bit log-encoded intensity)
     float4 albedoIntensity = _MaterialAlbedoIntensity.SampleLevel(pointClampSampler, uvw, 0);
     float emissionIntensity = DecodeEmissionIntensityFrom8Bit(albedoIntensity.a);
@@ -176,7 +196,8 @@ void CSComputeRadiance(uint3 id : SV_DispatchThreadID)
     // Radiate reflected incoming light plus emissive contribution.
     // float3 safeAlbedo = min(albedoIntensity.rgb, float3(0.9f, 0.9f, 0.9f));
     float3 safeAlbedo = albedoIntensity.rgb;
-    outgoingLight += ((surfaceIrradiance + sunLight + pointLight + spotLight) * safeAlbedo.rgb) + emissiveLight;
+    float3 directLight = sunLight + pointLight + spotLight;
+    outgoingLight += ((surfaceIrradiance + directLight) * safeAlbedo.rgb) + emissiveLight;
     _RadianceFieldWrite[id] = float4(outgoingLight, 1.0);
 }
 
@@ -201,6 +222,11 @@ void CSComputeIrradiancePathTracing(uint3 id : SV_DispatchThreadID)
 
     float3 incomingLight = float3(0, 0, 0);
     float3 surfaceNormal = GetNormalFromSDF(voxelCenter);
+    // Same self-occlusion bias as the radiance pass: lift the ray start past
+    // the EPSILON shell around the originating voxel so near-surface voxels
+    // don't immediately self-hit on every gathered direction. See the longer
+    // explanation in CSComputeRadiance and Volume.hlsl.
+    float startOffset = ComputeRaymarchStartOffset(dist);
     uint rayCount = max(_RaysPerFrame, 1u);
 
     [loop] // TODO: Change to [unroll] and rayCount to compile time constant (1=Mobile, 4=PC)
@@ -214,7 +240,7 @@ void CSComputeIrradiancePathTracing(uint3 id : SV_DispatchThreadID)
         }
 
         float3 hitPos;
-        float lit = RaymarchSDF(voxelCenter, rayDir, hitPos);
+        float lit = RaymarchSDF(voxelCenter, rayDir, startOffset, MAX_SDF_DIST, hitPos);
         if (lit == 0) {
             // Sample value half a voxel away from the surface hit point, to avoid sampling a voxel center inside the surface.
             float3 surfaceUVW = WorldToVoxelUV(hitPos - rayDir * _VoxelSize * 0.51);
@@ -292,7 +318,21 @@ void CSComputeIrradianceLPV(uint3 id : SV_DispatchThreadID)
 
     // Decay controls retention of propagated light.
     // Inverted decay (1 - decay) is used as radiance injection weight.
-    float3 injectedRadiance = _RadianceField.Load(int4(id, 0)).rgb * (1.0 - _LpvDecay);
+    //
+    // LPV is sampled on the air side of surfaces, but direct/bounce radiance is
+    // concentrated in the near-surface shell. Loading only _RadianceField[id]
+    // makes an air receiver voxel miss nearby lit shell voxels unless the light
+    // happens to land on exactly the same cell. That showed up as roofs lighting
+    // while floors / side walls stayed dark.
+    //
+    // Pull the injection sample back toward the nearest surface until the sample
+    // sits about half a voxel outside it. This keeps the lookup on the air side
+    // while allowing LPV receiver voxels to see the directly lit shell.
+    float3 surfaceNormal = GetNormalFromSDF(voxelCenter);
+    float radianceBackoff = max(dist - (_VoxelSize.x * 0.5f), 0.0f);
+    float3 radianceSamplePos = voxelCenter - surfaceNormal * radianceBackoff;
+    float3 radianceUVW = WorldToVoxelUV(radianceSamplePos);
+    float3 injectedRadiance = _RadianceField.SampleLevel(linearClampSampler, radianceUVW, 0).rgb * (1.0 - _LpvDecay);
     float3 incomingLight = max((propagated * _LpvDecay) + injectedRadiance, 0.0);
     _IrradianceFieldWrite[id] = float4(incomingLight, 1.0);
 }

--- a/package/Runtime/Shaders/Includes/Volume.hlsl
+++ b/package/Runtime/Shaders/Includes/Volume.hlsl
@@ -1,12 +1,46 @@
  // Global shader variables used by all fields.
-// Use a larger epsilon for raymarching to avoid light leaking through thin walls.
-// Because SDF:s have rounded corners, a ray can get very close to the surface without actually hitting it, which causes light to leak through. A larger epsilon means we consider it a hit even if we're not super close, which helps block light in these cases. The downside is that it can cause shadow acne or make shadows look blocky, especially on low-res volumes. A more robust solution would be to detect these near-hit cases and apply a bias based on the surface normal to prevent acne while still blocking light. 
-// Value depends on the wall thickness and voxel size.
-// Wall thickness 0.2, voxel size 0.16: requires 0.04
-// Wall thickness 0.5, voxel size 0.16: requires 0.02
-// TODO: Calculate and set this from C# side automatically.
-#define MAX_SDF_DIST 30.0
+//
+// EPSILON: hit threshold for SDF raymarching (RayMarchTex3D treats d <= EPSILON
+// as a surface hit and returns full occlusion).
+//
+// Why we need a non-trivial epsilon at all:
+//   The discrete SDF is reconstructed by trilinear filtering, which rounds off
+//   sharp features. A ray that grazes a thin wall can stay above d == 0 for
+//   the entire traversal even though geometrically it should have hit. With
+//   epsilon = 0 we would get pinhole light leaks through walls that are only
+//   one or two voxels thick. A positive epsilon converts those near-misses
+//   into hits and seals the wall.
+//
+// Trade-offs:
+//   * Too small  -> light leaks through thin walls / acute corners.
+//   * Too large  -> shadow acne; rays self-occlude when started near a surface
+//                   unless their startOffset clears the epsilon shell around
+//                   the originating voxel.
+//   * Effectively a per-step bias, so it is independent of step size; the
+//                   raymarcher's softness term scales with d/t, not with d - eps.
+//
+// Where the value matters:
+//   * Direct light visibility from CSComputeRadiance (sun/point/spot).
+//   * Path-traced bounce visibility in CSComputeIrradiancePathTracing.
+//   * Anything else that calls RaymarchSDF in this volume.
+// The fragment-side shadow shader (VoxelSdfShadows.hlsl) uses its own
+// _SdfShadowEpsilon supplied from C# so it can be tuned independently.
+//
+// Choosing a value:
+//   The minimum safe epsilon is roughly the largest amount the trilinearly
+//   reconstructed SDF can deviate from the true distance near a thin feature.
+//   That depends on wall thickness and voxel size:
+//     Wall thickness 0.2, voxel size 0.16 -> 0.04
+//     Wall thickness 0.5, voxel size 0.16 -> 0.02
+//   When raising EPSILON, raise the startOffset in the radiance/irradiance
+//   passes by the same amount so near-surface voxels are not self-occluded.
+//
+// TODO: Calculate and set this from C# side automatically based on the
+//       smallest wall thickness in the scene and the current voxel size.
 #define EPSILON 0.04
+#define RAYMARCH_MIN_STEP 0.01
+#define RAYMARCH_MAX_STEPS 64
+#define RAYMARCH_SOFTNESS 0.5
 
 #include "Raymarch.hlsl"
 
@@ -41,10 +75,20 @@ float3 GetNormalFromSDF(float3 pos) {
     );
 }
 
-float RaymarchSDF(float3 voxelCenter, float3 rayDir, out float3 hitPos) {
-    return RayMarchTex3D(_DistanceField, linearClampSampler, voxelCenter, rayDir, _VolumePosition, _VolumeSize, 0, MAX_SDF_DIST, EPSILON, 0.01, 64, 0.5, hitPos);
+// RayMarchTex3D treats d <= EPSILON as a hit. Starting exactly EPSILON away is
+// therefore still ambiguous because equality self-hits. The extra min-step
+// clearance guarantees the first sampled point is just outside the epsilon shell
+// in the common case where the ray is moving away from the surface.
+float ComputeRaymarchStartOffset(float dist)
+{
+    return max(0.0, (EPSILON + RAYMARCH_MIN_STEP) - dist);
 }
 
 float RaymarchSDF(float3 voxelCenter, float3 rayDir, float maxDistance, out float3 hitPos) {
-    return RayMarchTex3D(_DistanceField, linearClampSampler, voxelCenter, rayDir, _VolumePosition, _VolumeSize, 0, maxDistance, EPSILON, 0.01, 64, 0.5, hitPos);
+    return RayMarchTex3D(_DistanceField, linearClampSampler, voxelCenter, rayDir, _VolumePosition, _VolumeSize, 0, maxDistance, EPSILON, RAYMARCH_MIN_STEP, RAYMARCH_MAX_STEPS, RAYMARCH_SOFTNESS, hitPos);
+}
+
+// Overload with explicit startOffset (bias to avoid self-occlusion at near-surface voxels).
+float RaymarchSDF(float3 voxelCenter, float3 rayDir, float startOffset, float maxDistance, out float3 hitPos) {
+    return RayMarchTex3D(_DistanceField, linearClampSampler, voxelCenter, rayDir, _VolumePosition, _VolumeSize, startOffset, maxDistance, EPSILON, RAYMARCH_MIN_STEP, RAYMARCH_MAX_STEPS, RAYMARCH_SOFTNESS, hitPos);
 }

--- a/package/Runtime/Shaders/Includes/VoxelGi.hlsl
+++ b/package/Runtime/Shaders/Includes/VoxelGi.hlsl
@@ -11,12 +11,44 @@ float3 _RadianceFieldVoxelSize; // meters per voxel
 // Main Sampling Function
 float3 SampleVoxelGI(float3 worldPos, float3 normal)
 {
-    // - Voxel sampling offset -
-    // Problem: If you sample exactly at the surface (worldPos), you might 
-    // be reading the voxel *inside* the wall, which is dark.
-    // Fix: Push the sample point out into the air along the normal.
-    // A value of 0.5 to 1.0 times the voxel size usually works best.
-    float3 samplePos = worldPos + (normal * _RadianceFieldVoxelSize * 0.1);
+    // -- Read-side voxel sampling offset --
+    //
+    // Trilinear sampling of the irradiance field at a wall surface will blend
+    // the (lit) air voxel and the (dark / inside-geometry) boundary voxel.
+    // For an axis-aligned wall the surface sits exactly on a voxel boundary,
+    // so the blend weight on the dark voxel is up to 50%. Without an offset
+    // the wall reads as half-bright at best, fully black at worst.
+    //
+    // Pushing the sample point along the surface normal by 0.5 * voxelSize is
+    // the principled minimum for this grid. LightingVolume expands the baked
+    // bounds so the SDF / GI voxels stay cubic, so the scalar voxel edge length
+    // is enough here. Using the diagonal would overshoot and pull light from the
+    // next cell, increasing bleed.
+    //
+    // We do this on the read side rather than the bake side because the
+    // fragment shader has access to the true geometric/normal-mapped surface
+    // normal, which is much more reliable than the SDF gradient near corners
+    // (the SDF is rounded by construction, so its normal is unstable there).
+    float voxel = _RadianceFieldVoxelSize.x;
+    float3 unitNormal = normalize(normal);
+    float desiredOffset = 0.5 * voxel;
+
+    // Clamp the offset by the SDF distance at the proposed point. This handles
+    // two failure modes that a fixed offset cannot:
+    //   * Thin walls (thickness <= 1 voxel): if 0.5 * voxel pushes through to
+    //     the *other* surface of the wall, sdfAtOffset becomes small/negative
+    //     and we shrink the offset, preventing through-wall light bleed.
+    //   * Concave (inside) corners: the rounded SDF makes the corner voxel
+    //     dimmer than its neighbors. Without clamping we would be tempted to
+    //     reduce the offset everywhere; with clamping the corner naturally
+    //     pulls the sample back toward worldPos, accepting the corner voxel's
+    //     own (modest) value instead of mis-sampling a brighter neighbor.
+    // The small floor keeps a minimum escape from the dark boundary voxel
+    // even when the SDF reports near-zero distance.
+    float3 probePos = worldPos + normal * desiredOffset;
+    float sdfAtProbe = SampleSDF(probePos);
+    float offset = max(0.05 * voxel, min(desiredOffset, sdfAtProbe));
+    float3 samplePos = worldPos + unitNormal * offset;
 
     // Normalize position to [0,1] for texture sampling. Assumes the volume is axis-aligned and starts at _VolumePosition.
     float3 uvw = WorldToVoxelUV(samplePos);

--- a/package/Runtime/Shaders/Includes/VoxelSdfShadows.hlsl
+++ b/package/Runtime/Shaders/Includes/VoxelSdfShadows.hlsl
@@ -15,7 +15,6 @@ float3 _SdfBoundsMin;
 float3 _SdfBoundsSize;
 float3 _VoxelResolution; // resolution of the bitmask voxel grid (set from C# as float vector)
 
-float _SdfShadowMaxDistance;
 float _SdfShadowEpsilon;
 float _SdfShadowMinStep;
 float _SdfShadowStartOffset;
@@ -30,10 +29,16 @@ inline bool SdfWorldToUVW(float3 worldPos, out float3 uvw)
 }
 
 // Returns 0..1: fully shadowed to fully lit..
-inline float GetShadowFromSdf(float3 dir, float3 worldPos)
+inline float GetShadowFromSdf(float3 dir, float3 worldPos, float startOffset, float maxDistance)
 {
-    half lit = RayMarchTex3D(_SdfTex, sampler_SdfTex, worldPos, dir, _SdfBoundsMin, _SdfBoundsSize, _SdfShadowStartOffset, _SdfShadowMaxDistance, _SdfShadowEpsilon, _SdfShadowMinStep, _SdfShadowMaxSteps, _SdfShadowSoftness);
+    half lit = RayMarchTex3D(_SdfTex, sampler_SdfTex, worldPos, dir, _SdfBoundsMin, _SdfBoundsSize, startOffset, maxDistance, _SdfShadowEpsilon, _SdfShadowMinStep, _SdfShadowMaxSteps, _SdfShadowSoftness);
     return lit;
+}
+
+inline float GetShadowFromSdf(float3 dir, float3 worldPos, float maxDistance)
+{
+    float startOffset = min(_SdfShadowStartOffset, maxDistance * 0.5);
+    return GetShadowFromSdf(dir, worldPos, startOffset, maxDistance);
 }
 
 #endif

--- a/package/Runtime/Shaders/VoxelShadowTest.shader
+++ b/package/Runtime/Shaders/VoxelShadowTest.shader
@@ -42,6 +42,9 @@ Shader "Lotec/Voxel Lighting/SDF Shadow Test"
             #pragma multi_compile __ SDF_ONLY BITMASK_POINT BITMASK_4TAP BITMASK_RAY3 BITMASK_8TAP
             #pragma multi_compile SDF_AO_OFF SDF_AO_LQ SDF_AO_HQ
 
+            #define MAX_POINT_LIGHTS 4
+            #define MAX_SPOT_LIGHTS 4
+
             CBUFFER_START(UnityPerMaterial)
                 TEXTURE2D(_BaseMap); SAMPLER(sampler_BaseMap);
                 TEXTURE2D(_BumpMap); SAMPLER(sampler_BumpMap);
@@ -51,6 +54,14 @@ Shader "Lotec/Voxel Lighting/SDF Shadow Test"
                 TEXTURE2D(_EmissionMap); SAMPLER(sampler_EmissionMap);
                 float4 _EmissionColor;
             CBUFFER_END
+
+            uint _PointLightCount;
+            float4 _PointLightPositionRange[MAX_POINT_LIGHTS];
+            float4 _PointLightColor[MAX_POINT_LIGHTS];
+            uint _SpotLightCount;
+            float4 _SpotLightPositionRange[MAX_SPOT_LIGHTS];
+            float4 _SpotLightDirectionAngleScale[MAX_SPOT_LIGHTS];
+            float4 _SpotLightColorAngleOffset[MAX_SPOT_LIGHTS];
 
             struct v {
                 float4 positionOS : POSITION;
@@ -106,29 +117,116 @@ Shader "Lotec/Voxel Lighting/SDF Shadow Test"
                 #endif
             }
 
-            // Default to SDF if no keyword is set
-            inline half GetShadow(Light light, float3 worldPos, float3 normal)
-            {
+            // Default to SDF if no keyword is set.
+            inline half GetShadow(float3 worldPos, float3 lightDir, float3 normal) {
                 #if defined(BITMASK_POINT) || defined(BITMASK_4TAP) || defined(BITMASK_RAY3) || defined(BITMASK_8TAP)
-                    return GetFinalShadow2(worldPos, normalize(light.direction), normal);
-                    // return GetFinalShadow(worldPos, normalize(light.direction));
+                    return GetFinalShadow2(worldPos, normalize(lightDir), normal);
+                    // return GetFinalShadow(worldPos, normalize(lightDir));
                 #else
-                    return GetShadowFromSdf(normalize(light.direction), worldPos);
+                    return GetShadowFromSdf(normalize(lightDir), worldPos, 1.0e+10f);
                 #endif
+            }
+
+            inline half GetShadow(float3 worldPos, float3 lightDir, float3 normal, float maxDistance) {
+                float3 normalizedLightDir = normalize(lightDir);
+
+                // The bitmask field stores directional occlusion to infinity, so it
+                // cannot stop at a nearby point/spot light. Use finite-distance SDF
+                // shadows for local lights so blockers behind the light do not shadow it.
+                return GetShadowFromSdf(normalizedLightDir, worldPos, maxDistance);
+            }
+
+            inline float GetLocalLightRangeAttenuation(float distSq, float rangeSq) {
+                float rangeFade = saturate(1.0 - (distSq / max(rangeSq, 1e-6)));
+                return rangeFade * rangeFade;
+            }
+
+            inline half3 GetDirectLighting(float3 worldPos, half3 normal, half3 albedo, float3 lightDir, half3 lightColor, float attenuation) {
+                half3 normalizedLightDir = normalize(lightDir);
+                half ndotl = saturate(dot(normal, normalizedLightDir));
+                if (ndotl <= 0.0h)
+                    return 0.0h;
+
+                half shadow = GetShadow(worldPos, normalizedLightDir, normal);
+                return albedo * lightColor * (ndotl * shadow * attenuation);
+            }
+
+            inline half3 GetDirectLighting(float3 worldPos, half3 normal, half3 albedo, float3 lightDir, half3 lightColor, float attenuation, float shadowDistance) {
+                half3 normalizedLightDir = normalize(lightDir);
+                half ndotl = saturate(dot(normal, normalizedLightDir));
+                if (ndotl <= 0.0h)
+                    return 0.0h;
+
+                half shadow = GetShadow(worldPos, normalizedLightDir, normal, shadowDistance);
+                return albedo * lightColor * (ndotl * shadow * attenuation);
+            }
+
+            inline half3 GetMainDirectLighting(Light light, float3 worldPos, half3 normal, half3 albedo) {
+                return GetDirectLighting(worldPos, normal, albedo, light.direction, light.color, 1.0);
+            }
+
+            inline half3 GetPointLightDirect(float3 worldPos, half3 normal, half3 albedo) {
+                half3 totalLight = 0.0h;
+                uint pointLightCount = min(_PointLightCount, (uint)MAX_POINT_LIGHTS);
+
+                [loop]
+                for (uint lightIndex = 0u; lightIndex < pointLightCount; lightIndex++)
+                {
+                    float4 positionRange = _PointLightPositionRange[lightIndex];
+                    float3 toLight = positionRange.xyz - worldPos;
+                    float surfaceDistSq = dot(toLight, toLight);
+                    if (surfaceDistSq <= 1e-6)
+                        continue;
+                    float rangeSq = positionRange.w * positionRange.w;
+                    if (surfaceDistSq >= rangeSq)
+                        continue;
+
+                    float invDistance = rsqrt(surfaceDistSq);
+                    float distanceToLight = surfaceDistSq * invDistance;
+                    float3 lightDir = toLight * invDistance;
+                    float attenuation = GetLocalLightRangeAttenuation(surfaceDistSq, rangeSq);
+                    totalLight += GetDirectLighting(worldPos, normal, albedo, lightDir, _PointLightColor[lightIndex].rgb, attenuation, distanceToLight);
+                }
+
+                return totalLight;
+            }
+
+            inline half3 GetSpotLightDirect(float3 worldPos, half3 normal, half3 albedo) {
+                half3 totalLight = 0.0h;
+                uint spotLightCount = min(_SpotLightCount, (uint)MAX_SPOT_LIGHTS);
+
+                [loop]
+                for (uint lightIndex = 0u; lightIndex < spotLightCount; lightIndex++)
+                {
+                    float4 positionRange = _SpotLightPositionRange[lightIndex];
+                    float3 toLight = positionRange.xyz - worldPos;
+                    float surfaceDistSq = dot(toLight, toLight);
+                    if (surfaceDistSq <= 1e-6)
+                        continue;
+                    float rangeSq = positionRange.w * positionRange.w;
+                    if (surfaceDistSq >= rangeSq)
+                        continue;
+
+                    float invDistance = rsqrt(surfaceDistSq);
+                    float distanceToLight = surfaceDistSq * invDistance;
+                    float3 lightDir = toLight * invDistance;
+                    float4 directionAngleScale = _SpotLightDirectionAngleScale[lightIndex];
+                    float4 colorAngleOffset = _SpotLightColorAngleOffset[lightIndex];
+                    float coneAttenuation = saturate(dot(-lightDir, directionAngleScale.xyz) * directionAngleScale.w + colorAngleOffset.a);
+                    if (coneAttenuation <= 0.0)
+                        continue;
+
+                    float attenuation = GetLocalLightRangeAttenuation(surfaceDistSq, rangeSq) * (coneAttenuation * coneAttenuation);
+                    totalLight += GetDirectLighting(worldPos, normal, albedo, lightDir, colorAngleOffset.rgb, attenuation, distanceToLight);
+                }
+
+                return totalLight;
             }
 
             half4 frag(v2f IN) : SV_Target
             {
                 Light light = GetMainLight();
                 half3 N = GetNormal(IN);
-                half3 L = normalize(light.direction);
-
-                // Self shadowing factor
-                float ndotl = saturate(dot(N, L));
-                // Direct light shadowing, only if facing the light
-                float shadow = 1.0; // No shadow.
-                if (ndotl > 0)
-                    shadow = GetShadow(light, IN.positionWS, N);
 
                 // Albedo: texture modulated by base color
                 half3 texAlbedo = SAMPLE_TEXTURE2D(_BaseMap, sampler_BaseMap, IN.uv).rgb;
@@ -143,10 +241,13 @@ Shader "Lotec/Voxel Lighting/SDF Shadow Test"
                 // Global Illumination from Voxel GI field
                 float3 gi = SampleVoxelGI(IN.positionWS, N);
                 float ao = GetAmbientOcclusionFromSdf(IN.positionWS, N);
+                half3 directLighting = GetMainDirectLighting(light, IN.positionWS, N, albedo);
+                directLighting += GetPointLightDirect(IN.positionWS, N, albedo);
+                directLighting += GetSpotLightDirect(IN.positionWS, N, albedo);
 
                 // float3 lit = albedo * gi; // DEBUG: Indirect lit only for testing
                 half3 lit =
-                    albedo * light.color * ndotl * shadow // Direct lit
+                    directLighting // Direct lit
                     + albedo * gi * ao // Indirect lit (ambient occlusion from SDF)
                     // + light.color * spec * shadow // Specular lit
                     ;


### PR DESCRIPTION
* Move direct lighting and shadows for point and spot to fragment shader.
* Ensure cubic voxels.
* Base max distance on volume size